### PR TITLE
Remove gevent

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -8,12 +8,8 @@ Requirements
 
 Install the following prerequisites using `pip`:
 
-* `gevent`
 * `sseclient`
 * `websocket-client`
-
-The `gevent` package in turn requires Python headers.
-In Debian based distributions (such as Ubuntu and Raspbian) they are called `python-dev`.
 
 Compatibility
 -------------

--- a/README.md
+++ b/README.md
@@ -6,12 +6,8 @@ Python client proxy for [SignalR](http://signalr.net/).
 
 Install the following prerequisites using `pip`:
 
-* `gevent`
 * `sseclient`
 * `websocket-client`
-
-The `gevent` package in turn requires Python headers.
-In Debian based distributions (such as Ubuntu and Raspbian) they are called `python-dev`.
 
 ## Compatibility
 

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
     ],
     keywords='signalr',
     packages=find_packages(),
-    install_requires=['gevent', 'websocket-client', 'sseclient', 'requests']
+    install_requires=['websocket-client', 'sseclient', 'requests']
 )

--- a/signalr/transports/_sse_transport.py
+++ b/signalr/transports/_sse_transport.py
@@ -12,11 +12,17 @@ class ServerSentEventsTransport(Transport):
         return 'serverSentEvents'
 
     def start(self, connection):
-        self.__response = sseclient.SSEClient(self._get_url(connection, 'connect'), session=self._session)
+        connect_url = self._get_url(connection, 'connect')
+        self.__response = \
+            iter(sseclient.SSEClient(connect_url, session=self._session))
         self._session.get(self._get_url(connection, 'start'))
 
         def _receive():
-            for notification in self.__response:
+            try:
+                notification = next(self.__response)
+            except StopIteration:
+                return
+            else:
                 if notification.data != 'initialized':
                     self._handle_notification(notification.data)
 

--- a/signalr/transports/_ws_transport.py
+++ b/signalr/transports/_ws_transport.py
@@ -26,9 +26,8 @@ class WebSocketsTransport(Transport):
                                     cookie=self.__get_cookie_str())
 
         def _receive():
-            while True:
-                notification = self.ws.recv()
-                self._handle_notification(notification)
+            notification = self.ws.recv()
+            self._handle_notification(notification)
 
         return _receive
 


### PR DESCRIPTION
The current implementation fails to forward messages received from the server to a callback registered via `some_hub.client.on('method', callback)`. The reason for this is that the listener which polls for incoming messages is spawned via `gevent.spawn(listener)`, but (at least in the source code of this repository) no other method such as `gevent.joinall()` is ever called. This results in the listener never actually running. This pull request replaces `gevent` by standard Python threads to fix the problem. As a result, the dependency on `gevent` can be dropped.