### PR TITLE
Handle bad response codes in negotiate

### DIFF
--- a/signalr/transports/_transport.py
+++ b/signalr/transports/_transport.py
@@ -26,6 +26,8 @@ class Transport:
                                   connectionData=self._connection.data)
         negotiate = self._session.get(url)
 
+        negotiate.raise_for_status()
+
         return negotiate.json()
 
     @abstractmethod


### PR DESCRIPTION
Requests will raise automatically a custom exception if the HTTP response code is bad (4xx or 5xx).

Refer to: http://docs.python-requests.org/en/master/user/quickstart/#response-status-codes