### PR TITLE
support query string in connection

### DIFF
--- a/signalr/__init__.py
+++ b/signalr/__init__.py
@@ -1,6 +1,7 @@
 from gevent import monkey
 
 monkey.patch_socket()
+monkey.patch_ssl()
 
 from ._connection import Connection
 

--- a/signalr/_connection.py
+++ b/signalr/_connection.py
@@ -11,6 +11,7 @@ class Connection:
     def __init__(self, url, session):
         self.url = url
         self.__hubs = {}
+        self.qs = {}
         self.__send_counter = -1
         self.token = None
         self.data = None

--- a/signalr/transports/_transport.py
+++ b/signalr/transports/_transport.py
@@ -67,6 +67,7 @@ class Transport:
     @staticmethod
     def __get_base_url(url, connection, action, **kwargs):
         args = kwargs.copy()
+        args.update(connection.qs)
         args['clientProtocol'] = connection.protocol_version
         query = '&'.join(['{key}={value}'.format(key=key, value=quote_plus(args[key])) for key in args])
 


### PR DESCRIPTION
I needed to send additional query string as parameters to my web hub (for authentication) so i added qs (that is how the parameter is called in the js API) to each connection (in js the qs is for hub)
Very simple stright forword change 
Thanks
Gal