### PR TITLE
Use requests json parsing helper (Fixes #22)

### DIFF
--- a/signalr/transports/_sse_transport.py
+++ b/signalr/transports/_sse_transport.py
@@ -24,7 +24,7 @@ class ServerSentEventsTransport(Transport):
 
     def send(self, data):
         response = self._session.post(self._get_url('send'), data={'data': json.dumps(data)})
-        parsed = json.loads(response.content)
+        parsed = response.json()
         self._connection.received.fire(**parsed)
 
     def close(self):


### PR DESCRIPTION
On Python 3 response.content is bytes not str, this just dodges the issue entirely.