### PR TITLE
Make `Connection.wait` return `True` when connection has closed

### DIFF
--- a/signalr/_connection.py
+++ b/signalr/_connection.py
@@ -57,7 +57,9 @@ class Connection:
         self.started = True
 
     def wait(self, timeout=30):
-        gevent.joinall([self.__greenlet], timeout)
+        self.__greenlet.join()
+
+        return self.__greenlet.ready()
 
     def send(self, data):
         self.__transport.send(data)


### PR DESCRIPTION
This is useful when you use `Connection.wait` in a loop (with a timeout) and want to exit when the connection has closed.