### PR TITLE
Exposed ConnectionId on Connection objects.

### DIFF
--- a/signalr/_connection.py
+++ b/signalr/_connection.py
@@ -14,6 +14,7 @@ class Connection:
         self.qs = {}
         self.__send_counter = -1
         self.token = None
+        self.id = None
         self.data = None
         self.received = EventHook()
         self.error = EventHook()
@@ -46,6 +47,7 @@ class Connection:
 
         negotiate_data = self.__transport.negotiate()
         self.token = negotiate_data['ConnectionToken']
+        self.id = negotiate_data['ConnectionId']
 
         listener = self.__transport.start()
 


### PR DESCRIPTION
Our application needs access to the ConnectionId, not just the ConnectionToken on the ConnectionClass.